### PR TITLE
qcow2: Support for be32toh and be64toh for glibc prior to 2008

### DIFF
--- a/qcow2.c
+++ b/qcow2.c
@@ -7,6 +7,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <endian.h>
+#include <byteswap.h>
 #include <string.h>
 #include <sys/mman.h>
 
@@ -36,6 +37,24 @@ struct qcow2 {
 		uint64_t offset;	/* 0 when unused */
 	} cluster[KIND_MAX];
 };
+
+/* Usually provided by endian.h, needed for glibc pre-2008 */
+
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+#  ifndef be32toh
+#    define be32toh(x) bswap_32 (x)
+#  endif
+#  ifndef be64toh
+#    define be64toh(x) bswap_64 (x)
+#  endif
+#else
+#  ifndef be32toh
+#    define be32toh(x) (x)
+#  endif
+#  ifndef be64toh
+#    define be64toh(x) (x)
+#  endif
+#endif
 
 /* Endian conversion with unaligned pointers */
 


### PR DESCRIPTION
glibc support for be32toh and be64toh was added on 15 May 2008
by Ulrich Drepper.  For using this library for glibc-2.5 it's necessary
to fill this little gap.