### PR TITLE
Makefile: define _GNU_SOURCE for pread purposes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-CFLAGS ?= -Wall -pedantic -g
+CFLAGS ?= -Wall -pedantic -g -D_GNU_SOURCE
 OBJS = catqcow2.o qcow2.o
 
 catqcow2: $(OBJS)


### PR DESCRIPTION
glibc-2.5 needs __USE_UNIX98 defined